### PR TITLE
Delayed updateLatency() call until after the plugin has been initialised with new sample rate and block size data

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -735,8 +735,6 @@ public:
 
             setRateAndBufferSizeDetails ((double) newSampleRate, estimatedSamplesPerBlock);
 
-            updateLatency();
-
             zerostruct (timeStamp);
             timeStamp.mSampleTime = 0;
             timeStamp.mHostTime = GetCurrentHostTime (0, newSampleRate, isAUv3);
@@ -760,6 +758,10 @@ public:
                 {
                     prepared = false;
                     AudioUnitUninitialize (audioUnit);
+                }
+                else
+                {
+                    updateLatency();
                 }
             }
         }


### PR DESCRIPTION
This change fixes an issue in which getLatencySamples() returns the wrong latency when a plugins latency changes based on the sample rate / block size.